### PR TITLE
Implement friendly names and switch to Grid.js

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ options:
       ip: 192.168.1.15
   dhcp_clients_friendly_names:
     - mac: dd:ee:aa:dd:bb:ee
-      name: "This is a friendly name to label this host, even if its get a dynamic IP"
+      name: "This is a friendly name to label this host, even if it gets a dynamic IP"
 schema:
   default_lease: str
   network:

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: feature-test-templ
+version: feature-friendly-names
 slug: dnsmasq-dhcp
 name: Dnsmasq-DHCP
 description: A DHCP server based on dnsmasq

--- a/dhcp-clients-webapp-backend/go.mod
+++ b/dhcp-clients-webapp-backend/go.mod
@@ -4,4 +4,4 @@ go 1.23.1
 
 require github.com/gorilla/websocket v1.5.3
 
-require github.com/b0ch3nski/go-dnsmasq-utils v0.1.0 // indirect
+require github.com/b0ch3nski/go-dnsmasq-utils v0.1.1-0.20240920072747-86fdb4624c7f // indirect

--- a/dhcp-clients-webapp-backend/go.mod
+++ b/dhcp-clients-webapp-backend/go.mod
@@ -4,4 +4,4 @@ go 1.23.1
 
 require github.com/gorilla/websocket v1.5.3
 
-require github.com/b0ch3nski/go-dnsmasq-utils v0.1.1-0.20240920072747-86fdb4624c7f // indirect
+require github.com/b0ch3nski/go-dnsmasq-utils v0.1.1 // indirect

--- a/dhcp-clients-webapp-backend/go.sum
+++ b/dhcp-clients-webapp-backend/go.sum
@@ -1,4 +1,6 @@
 github.com/b0ch3nski/go-dnsmasq-utils v0.1.0 h1:SfUaYFNCp9t0Vh5uy3E84j4Ok8O/isUC0h7F/N0AxqQ=
 github.com/b0ch3nski/go-dnsmasq-utils v0.1.0/go.mod h1:vdD5vOfYL0GDBSvWk/+YXJo8SAXOrcY0Ey8E7BoupgM=
+github.com/b0ch3nski/go-dnsmasq-utils v0.1.1-0.20240920072747-86fdb4624c7f h1:HSuBZjQrg6rh3HkuCBBiH9JFYzRZacDhminhbwCHUHs=
+github.com/b0ch3nski/go-dnsmasq-utils v0.1.1-0.20240920072747-86fdb4624c7f/go.mod h1:vdD5vOfYL0GDBSvWk/+YXJo8SAXOrcY0Ey8E7BoupgM=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/dhcp-clients-webapp-backend/go.sum
+++ b/dhcp-clients-webapp-backend/go.sum
@@ -2,5 +2,7 @@ github.com/b0ch3nski/go-dnsmasq-utils v0.1.0 h1:SfUaYFNCp9t0Vh5uy3E84j4Ok8O/isUC
 github.com/b0ch3nski/go-dnsmasq-utils v0.1.0/go.mod h1:vdD5vOfYL0GDBSvWk/+YXJo8SAXOrcY0Ey8E7BoupgM=
 github.com/b0ch3nski/go-dnsmasq-utils v0.1.1-0.20240920072747-86fdb4624c7f h1:HSuBZjQrg6rh3HkuCBBiH9JFYzRZacDhminhbwCHUHs=
 github.com/b0ch3nski/go-dnsmasq-utils v0.1.1-0.20240920072747-86fdb4624c7f/go.mod h1:vdD5vOfYL0GDBSvWk/+YXJo8SAXOrcY0Ey8E7BoupgM=
+github.com/b0ch3nski/go-dnsmasq-utils v0.1.1 h1:dHra9Hyq4HDUuA7nolJyVNUA5I+rchI300cZ2FTDlEE=
+github.com/b0ch3nski/go-dnsmasq-utils v0.1.1/go.mod h1:vdD5vOfYL0GDBSvWk/+YXJo8SAXOrcY0Ey8E7BoupgM=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -59,7 +59,7 @@
                     { name: 'Hostname', sort: true }, 
                     { name: 'IP Address',  sort: { compare: compareIPs } }, 
                     { name: 'MAC Address', sort: true }, 
-                    { name: 'Expires at', sort: true }
+                    { name: 'Expires in', sort: true }
                 ],
                 data: [],
                 sort: true,

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -32,9 +32,11 @@
             return hexString;
         }
 
+        var grid = null;
+
         function initTable() {
-            // Inizializza la tabella con Grid.js
-            const grid = new gridjs.Grid({
+            console.log("Initializing grid.js table");
+            grid = new gridjs.Grid({
                 columns: ['ID', 'Friendly Name', 'Hostname', 'IP Address', 'MAC Address', 'Expires at'], // Definisci le colonne
                 data: [],
                 search: true, // Abilita la ricerca

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -32,6 +32,22 @@
             return hexString;
         }
 
+        // Compare function for IP addresses
+        function compareIPs(ip1, ip2) {
+            const ipToNum = (ip) => {
+                return ip.split('.').reduce((acc, octet) => {
+                    return (acc << 8) + parseInt(octet, 10);
+                }, 0);
+            };
+
+            const num1 = ipToNum(ip1);
+            const num2 = ipToNum(ip2);
+
+            if (num1 < num2) return -1;
+            if (num1 > num2) return 1;
+            return 0;
+        }
+
         var grid = null;
 
         function initTable() {
@@ -41,7 +57,7 @@
                     { name: 'ID', sort: true }, 
                     { name: 'Friendly Name', sort: true }, 
                     { name: 'Hostname', sort: true }, 
-                    { name: 'IP Address', sort: true }, 
+                    { name: 'IP Address',  sort: { compare: compareIPs } }, 
                     { name: 'MAC Address', sort: true }, 
                     { name: 'Expires at', sort: true }
                 ],

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -3,6 +3,10 @@
 <head>
     <title>DHCP Clients</title>
 
+    <!-- Include la libreria Grid.js -->
+    <link href="https://unpkg.com/gridjs/dist/theme/mermaid.min.css" rel="stylesheet" />
+    <script src="https://unpkg.com/gridjs/dist/gridjs.umd.js"></script>
+
     <style>
         .solidBorder {
             border: 1px solid;
@@ -29,6 +33,19 @@
         }
 
         var ws = new WebSocket("wss://{{.WebSocketHost}}/ws");
+
+        // Inizializza la tabella con Grid.js
+        let tableData = [];
+        const grid = new gridjs.Grid({
+            columns: ['ID', 'Friendly Name', 'Hostname', 'IP Address', 'MAC Address', 'Expires at'], // Definisci le colonne
+            data: tableData,
+            search: true, // Abilita la ricerca
+            pagination: {
+                limit: 20 // Imposta il limite di righe per pagina
+            }
+        }).render(document.getElementById('table-wrapper'));
+
+
 
         ws.onopen = function(event) {
             console.log("Websocket started successfully");
@@ -67,9 +84,13 @@
                 message.style.display = 'none';
 
                 console.log("Websocket connection: received " + data.length + " items from websocket");
+                
+                tableData = [];
                 data.forEach(function(item, index) {
                     console.log(`Item ${index + 1}:`, item);
-                    var row = document.createElement("tr");
+                    
+                    
+                    /*var row = document.createElement("tr");
                     
                     var friendlyName = document.createElement("td");
                     var hostnameCell = document.createElement("td");
@@ -89,8 +110,16 @@
                     row.appendChild(macCell);
                     row.appendChild(expireCell);
 
-                    tableBody.appendChild(row);
+                    tableBody.appendChild(row);*/
+
+                    // Aggiungi i nuovi dati alla tabella
+                    tableData.push([index, item.FriendlyName, item.Lease.Hostname, item.Lease.IPAddr, base64ToHex(item.Lease.MacAddr), item.Lease.Expires]);
                 });
+
+                // Rerender della tabella con i nuovi dati
+                grid.updateConfig({
+                    data: tableData
+                }).forceRender();
             }
         };
     </script>
@@ -98,6 +127,8 @@
 <body>
     <h1>DHCP Clients</h1>
     <p id="message"></p>
+
+    <!--
     <table id="tableDhcp" class="solidBorder">
         <thead>
             <tr class="solidBorder">
@@ -109,9 +140,13 @@
             </tr>
         </thead>
         <tbody id="tableBody" class="solidBorder">
-            <!-- data is dynamically populated here -->
+            <!-- data is dynamically populated here 
         </tbody>
     </table>
+    -->
+
+    <!-- Div che conterrà la tabella Grid.js -->
+    <div id="table-wrapper"></div>
 
     <p>Notes:</p>
     <ul>

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -3,7 +3,7 @@
 <head>
     <title>DHCP Clients</title>
 
-    <!-- Include la libreria Grid.js -->
+    <!-- add Grid.js library -->
     <link href="https://unpkg.com/gridjs/dist/theme/mermaid.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/gridjs/dist/gridjs.umd.js"></script>
 
@@ -37,12 +37,18 @@
         function initTable() {
             console.log("Initializing grid.js table");
             grid = new gridjs.Grid({
-                columns: ['ID', 'Friendly Name', 'Hostname', 'IP Address', 'MAC Address', 'Expires at'], // Definisci le colonne
+                columns: [
+                    { name: 'ID', sort: true }, 
+                    { name: 'Friendly Name', sort: true }, 
+                    { name: 'Hostname', sort: true }, 
+                    { name: 'IP Address', sort: true }, 
+                    { name: 'MAC Address', sort: true }, 
+                    { name: 'Expires at', sort: true }
+                ],
                 data: [],
-                search: true, // Abilita la ricerca
-                pagination: {
-                    limit: 20 // Imposta il limite di righe per pagina
-                }
+                sort: true,
+                search: true,
+                pagination: { limit: 20 }
             }).render(document.getElementById('table-wrapper'));
         }
 
@@ -103,7 +109,7 @@
                     console.log(`Item ${index + 1}:`, item);
 
                     // append new row
-                    tableData.push([index, item.FriendlyName, item.Lease.Hostname, item.Lease.IPAddr, base64ToHex(item.Lease.MacAddr), item.Lease.Expires]);
+                    tableData.push([index + 1, item.FriendlyName, item.Lease.Hostname, item.Lease.IPAddr, base64ToHex(item.Lease.MacAddr), item.Lease.Expires]);
                 });
 
                 // rerender the table

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -77,7 +77,7 @@
                     var macCell = document.createElement("td");
                     var expireCell = document.createElement("td");
 
-                    friendlyName.textContent = item.PrettyName;
+                    friendlyName.textContent = item.FriendlyName;
                     hostnameCell.textContent = item.Lease.Hostname;
                     ipCell.textContent = item.Lease.IPAddr;
                     macCell.textContent = base64ToHex(item.Lease.MacAddr);

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -73,59 +73,45 @@
                 console.error('Error while parsing JSON:', error);
             }
 
-            var tableDhcp = document.getElementById("tableDhcp");
-            var tableBody = document.getElementById("tableBody");
             var message = document.getElementById("message");
 
-            tableBody.innerHTML = "";
             if (data === null) {
                 console.log("Websocket connection: received an empty JSON");
-                tableDhcp.style.display = 'none';
-                message.innerText = "No DHCP clients so far."
-                message.style.display = 'block';
+
+                // clear the table
+                grid.updateConfig({
+                    data: []
+                }).forceRender();
+
+                message.innerText = "No DHCP clients so far.";
+
             } else if (!Array.isArray(data)) {
                 console.error("Websocket connection: expecting a JSON array, received something else", event.data);
-            } else {
-                tableDhcp.style.display = 'block';
-                message.style.display = 'none';
 
+                // clear the table
+                grid.updateConfig({
+                    data: []
+                }).forceRender();
+
+                message.innerText = "Internal error. Please report upstream together with Javascript logs.";
+
+            } else {
                 console.log("Websocket connection: received " + data.length + " items from websocket");
                 
                 tableData = [];
                 data.forEach(function(item, index) {
                     console.log(`Item ${index + 1}:`, item);
-                    
-                    
-                    /*var row = document.createElement("tr");
-                    
-                    var friendlyName = document.createElement("td");
-                    var hostnameCell = document.createElement("td");
-                    var ipCell = document.createElement("td");
-                    var macCell = document.createElement("td");
-                    var expireCell = document.createElement("td");
 
-                    friendlyName.textContent = item.FriendlyName;
-                    hostnameCell.textContent = item.Lease.Hostname;
-                    ipCell.textContent = item.Lease.IPAddr;
-                    macCell.textContent = base64ToHex(item.Lease.MacAddr);
-                    expireCell.textContent = item.Lease.Expires;
-
-                    row.appendChild(friendlyName);
-                    row.appendChild(hostnameCell);
-                    row.appendChild(ipCell);
-                    row.appendChild(macCell);
-                    row.appendChild(expireCell);
-
-                    tableBody.appendChild(row);*/
-
-                    // Aggiungi i nuovi dati alla tabella
+                    // append new row
                     tableData.push([index, item.FriendlyName, item.Lease.Hostname, item.Lease.IPAddr, base64ToHex(item.Lease.MacAddr), item.Lease.Expires]);
                 });
 
-                // Rerender della tabella con i nuovi dati
+                // rerender the table
                 grid.updateConfig({
                     data: tableData
                 }).forceRender();
+
+                message.innerText = "A total of " + data.length + " DHCP clients are tracked by the DHCP server:";
             }
         };
     </script>
@@ -134,24 +120,7 @@
     <h1>DHCP Clients</h1>
     <p id="message"></p>
 
-    <!--
-    <table id="tableDhcp" class="solidBorder">
-        <thead>
-            <tr class="solidBorder">
-                <th class="solidBorder">Friendly Name</th>
-                <th class="solidBorder">Hostname</th>
-                <th class="solidBorder">IP Address</th>
-                <th class="solidBorder">MAC Address</th>
-                <th class="solidBorder">Expires at</th>
-            </tr>
-        </thead>
-        <tbody id="tableBody" class="solidBorder">
-            <!-- data is dynamically populated here 
-        </tbody>
-    </table>
-    -->
-
-    <!-- Div che conterrà la tabella Grid.js -->
+    <!-- the Grid.js table will be attached to this DIV element -->
     <div id="table-wrapper"></div>
 
     <p>Notes:</p>

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -32,20 +32,24 @@
             return hexString;
         }
 
+        function initTable() {
+            // Inizializza la tabella con Grid.js
+            const grid = new gridjs.Grid({
+                columns: ['ID', 'Friendly Name', 'Hostname', 'IP Address', 'MAC Address', 'Expires at'], // Definisci le colonne
+                data: [],
+                search: true, // Abilita la ricerca
+                pagination: {
+                    limit: 20 // Imposta il limite di righe per pagina
+                }
+            }).render(document.getElementById('table-wrapper'));
+        }
+
+        document.addEventListener('DOMContentLoaded', initTable, false);
+
+
+        // websocket
+
         var ws = new WebSocket("wss://{{.WebSocketHost}}/ws");
-
-        // Inizializza la tabella con Grid.js
-        let tableData = [];
-        const grid = new gridjs.Grid({
-            columns: ['ID', 'Friendly Name', 'Hostname', 'IP Address', 'MAC Address', 'Expires at'], // Definisci le colonne
-            data: tableData,
-            search: true, // Abilita la ricerca
-            pagination: {
-                limit: 20 // Imposta il limite di righe per pagina
-            }
-        }).render(document.getElementById('table-wrapper'));
-
-
 
         ws.onopen = function(event) {
             console.log("Websocket started successfully");

--- a/dhcp-clients-webapp-backend/templates/index.templ.html
+++ b/dhcp-clients-webapp-backend/templates/index.templ.html
@@ -125,7 +125,7 @@
                     console.log(`Item ${index + 1}:`, item);
 
                     // append new row
-                    tableData.push([index + 1, item.FriendlyName, item.Lease.Hostname, item.Lease.IPAddr, base64ToHex(item.Lease.MacAddr), item.Lease.Expires]);
+                    tableData.push([index + 1, item.friendly_name, item.lease.hostname, item.lease.ip_addr, item.lease.mac_addr, item.lease.expires]);
                 });
 
                 // rerender the table


### PR DESCRIPTION
This PR allows to setup in the addon config "friendly names" for any number of MAC addresses.
It also switches from a plain basic HTML table to a Grid.js table.
Finally bumps version to 1.0.0