### PR TITLE
Remove hardcoded port 8080 and replace with configurable port

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,9 @@
 # as reported by the Github Action workflow 'publish.yaml', so that you can force HomeAssistant
 # to use the docker image of that feature branch instead of the docker image of 'main', by pointing
 # HomeAssistant to that feature branch
-version: 1.1.0
-slug: dnsmasq-dhcp
-name: Dnsmasq-DHCP
+version: 1.2.0
+slug: dnsmasq-dhcp-beta
+name: Dnsmasq-DHCP BETA
 description: A DHCP server based on dnsmasq
 url: https://github.com/f18m/ha-addon-dnsmasq-dhcp-server/tree/main
 advanced: true

--- a/config.yaml
+++ b/config.yaml
@@ -51,7 +51,7 @@ options:
     end_ip: 192.168.1.250
   ip_address_reservations: 
     - mac: aa:bb:cc:dd:ee:ff
-      name: "An important host with a static IP address assigned"
+      name: "An-important-host-with-reserved-IP"
       ip: 192.168.1.15
   dhcp_clients_friendly_names:
     - mac: dd:ee:aa:dd:bb:ee
@@ -79,10 +79,11 @@ schema:
     end_ip: str
   ip_address_reservations:
     - ip: str
-      mac: str
-      name: str
+      mac: match(^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$)
+      # the name in this case must be a valid hostname as per RFC 1123
+      name: match(^[a-zA-Z0-9\-.]*$)
   dhcp_clients_friendly_names:
-    - mac: str
+    - mac: match(^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$)
       name: str
   log_dhcp: bool
   log_web_ui: bool

--- a/config.yaml
+++ b/config.yaml
@@ -80,7 +80,8 @@ schema:
   ip_address_reservations:
     - ip: str
       mac: match(^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$)
-      # the name in this case must be a valid hostname as per RFC 1123
+      # the name in this case must be a valid hostname as per RFC 1123 since it is passed to dnsmasq
+      # that will refuse to start if an invalid hostname format is used
       name: match(^[a-zA-Z0-9\-.]*$)
   dhcp_clients_friendly_names:
     - mac: match(^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$)

--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,10 @@ options:
       name: "This is a friendly name to label this host, even if it gets a dynamic IP"
   log_dhcp: true
   log_web_ui: false
+  # this addon uses "host_network: true" so the internal HTTP server will bind on the interface
+  # provided as network.interface and will occupy a port there; the following parameter makes
+  # that port configurable to avoid conflicts with other services
+  web_ui_port: 8976
 schema:
   default_lease: str
   address_reservation_lease: str

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@
 # as reported by the Github Action workflow 'publish.yaml', so that you can force HomeAssistant
 # to use the docker image of that feature branch instead of the docker image of 'main', by pointing
 # HomeAssistant to that feature branch
-version: 1.2.0
+version: beta
 slug: dnsmasq-dhcp-beta
 name: Dnsmasq-DHCP BETA
 description: A DHCP server based on dnsmasq

--- a/config.yaml
+++ b/config.yaml
@@ -86,6 +86,7 @@ schema:
       name: str
   log_dhcp: bool
   log_web_ui: bool
+  web_ui_port: int
 startup: system
 privileged:
   - NET_ADMIN

--- a/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -10,10 +10,12 @@ bashio::log.info "Configuring nginx ingress..."
 declare ingress_interface
 declare ingress_port
 declare ingress_entry
+declare web_ui_port
 
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)
 ingress_entry=$(bashio::addon.ingress_entry)
+web_ui_port=$(bashio::config 'web_ui_port')
 
 if [ -z "$ingress_port" ]; then
     ingress_port=8100
@@ -26,3 +28,6 @@ sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ssl.conf
+
+sed -i "s|%%web_ui_port%%|${web_ui_port}|g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%web_ui_port%%|${web_ui_port}|g" /etc/nginx/servers/ssl.conf

--- a/rootfs/etc/nginx/servers/ingress.conf
+++ b/rootfs/etc/nginx/servers/ingress.conf
@@ -11,7 +11,7 @@ server {
 
     location / {
        # Proxy
-       proxy_pass http://127.0.0.1:8080/;
+       proxy_pass http://127.0.0.1:%%web_ui_port%%/;
 
        proxy_read_timeout       30000;
        proxy_redirect           off;

--- a/rootfs/etc/nginx/servers/ssl.conf
+++ b/rootfs/etc/nginx/servers/ssl.conf
@@ -10,7 +10,7 @@ server {
     }
 
     location %%ingress_entry%%/ {
-        set $upstream_port 8080;
+        set $upstream_port %%web_ui_port%%;
         proxy_pass http://127.0.0.1:$upstream_port;
     }
 }

--- a/rootfs/usr/share/tempio/dnsmasq.config
+++ b/rootfs/usr/share/tempio/dnsmasq.config
@@ -43,7 +43,7 @@ dhcp-option=42{{ range .network.ntp_resolved }},{{ . }}{{ end }}
 {{ if gt (len .ip_address_reservations) 0 }}
 {{ range .ip_address_reservations }}
 # Set static IP address reservations
-dhcp-host={{ .mac }},"{{ .name }}",{{ .ip }},{{ $.address_reservation_lease }}
+dhcp-host={{ .mac }},{{ .name }},{{ .ip }},{{ $.address_reservation_lease }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/rootfs/usr/share/tempio/dnsmasq.config
+++ b/rootfs/usr/share/tempio/dnsmasq.config
@@ -43,7 +43,7 @@ dhcp-option=42{{ range .network.ntp_resolved }},{{ . }}{{ end }}
 {{ if gt (len .ip_address_reservations) 0 }}
 {{ range .ip_address_reservations }}
 # Set static IP address reservations
-dhcp-host={{ .mac }},{{ .name }},{{ .ip }},{{ $.address_reservation_lease }}
+dhcp-host={{ .mac }},"{{ .name }}",{{ .ip }},{{ $.address_reservation_lease }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -41,10 +41,10 @@ configuration:
   #     description: The last IP address of the DHCP range that defines the DHCP address pool.
   ip_address_reservations:
     name: IP Address Reservations
-    description: List of MAC addresses / IP addresses pairs that are reserved.
+    description: List of MAC addresses / IP addresses pairs that are reserved. Strict regex validation is performed on MAC addresses and hostnames (use alphanumeric chars plus dot or hyphens only).
   dhcp_clients_friendly_names:
     name: DHCP Clients Friendly Names
-    description: List of MAC addresses / friendly-name pairs to help identify the DHCP clients in the Web UI.
+    description: List of MAC addresses / friendly-name pairs to help identify the DHCP clients in the Web UI. Strict regex validation is performed on MAC addresses.
 
   log_dhcp:
     name: Log DHCP
@@ -52,7 +52,6 @@ configuration:
   log_web_ui:
     name: Log Web UI
     description: Log all HTTP requests served by the add-on UI
-
   web_ui_port:
     name: Web UI Port
-    description: Port used by the internal HTTP server
+    description: Port used by the internal HTTP server. Change only if you get a conflict on the default port.

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -52,3 +52,7 @@ configuration:
   log_web_ui:
     name: Log Web UI
     description: Log all HTTP requests served by the add-on UI
+
+  web_ui_port:
+    name: Web UI Port
+    description: Port used by the internal HTTP server


### PR DESCRIPTION
This PR is:
* replacing the hardcoded port 8080 used by DHCP client backend with a configurable port, which defaults to 8967 (much less common)
* improving hostname and MAC address validations on the addon configuration